### PR TITLE
Adding manual action, staging separate from production branch

### DIFF
--- a/.github/workflows/graph-manual.yaml
+++ b/.github/workflows/graph-manual.yaml
@@ -11,12 +11,12 @@ on:
         description: 'Name of the subgraph'
         required: true
         default: 'subgraph-template'
-      org:
-        description: 'Name of the subgraph org or your account name'
+      account:
+        description: 'Name of the subgraph account or org name'
         required: true
-        default: ${{github.repository_owner}}
+        default: $GITHUB_ACTOR
       branch:
-        description: 'Branch to build (development, staging, master or another one)'
+        description: 'Branch to build (development, staging, master or another)'
         required: true
         default: 'development'
 
@@ -24,7 +24,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      GRAPH_SUBGRAPH_ORG: ${{ github.event.inputs.org }}
+      GRAPH_SUBGRAPH_ACCOUNT: ${{ github.event.inputs.account }}
       GRAPH_SUBGRAPH_NAME: ${{ github.event.inputs.subgraph }}
       GRAPH_CONFIG_FILE: subgraph.yaml
       NETWORK: ${{ github.event.inputs.network }}
@@ -40,7 +40,7 @@ jobs:
         run: yarn codegen:$NETWORK
       - uses: gtaschuk/graph-deploy@v0.1.0
         with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_access_token: ${{ secrets.GRAPH_ACCESS_TOKEN }}
           graph_subgraph_name: $GRAPH_SUBGRAPH_NAME
-          graph_account: $GRAPH_SUBGRAPH_ORG
+          graph_account: $GRAPH_SUBGRAPH_ACCOUNT
           graph_config_file: $GRAPH_CONFIG_FILE

--- a/.github/workflows/graph-manual.yaml
+++ b/.github/workflows/graph-manual.yaml
@@ -14,7 +14,6 @@ on:
       account:
         description: 'Name of the subgraph account or org name'
         required: true
-        default: $GITHUB_ACTOR
       branch:
         description: 'Branch to build (development, staging, master or another)'
         required: true

--- a/.github/workflows/graph-manual.yaml
+++ b/.github/workflows/graph-manual.yaml
@@ -1,4 +1,4 @@
-name: Deploy Graph
+name: Deploy Graph Manual
 
 on:
   workflow_dispatch:

--- a/.github/workflows/graph-manual.yaml
+++ b/.github/workflows/graph-manual.yaml
@@ -1,0 +1,46 @@
+name: Deploy Graph
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network to build for (mainnet, mumbai)'
+        required: true
+        default: 'mumbai'
+      subgraph:
+        description: 'Name of the subgraph'
+        required: true
+        default: 'subgraph-template'
+      org:
+        description: 'Name of the subgraph org or your account name'
+        required: true
+        default: ${{github.repository_owner}}
+      branch:
+        description: 'Branch to build (development, staging, master or another one)'
+        required: true
+        default: 'development'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GRAPH_SUBGRAPH_ORG: ${{ github.event.inputs.org }}
+      GRAPH_SUBGRAPH_NAME: ${{ github.event.inputs.subgraph }}
+      GRAPH_CONFIG_FILE: subgraph.yaml
+      NETWORK: ${{ github.event.inputs.network }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Codegen
+        run: yarn codegen:$NETWORK
+      - uses: gtaschuk/graph-deploy@v0.1.0
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: $GRAPH_SUBGRAPH_NAME
+          graph_account: $GRAPH_SUBGRAPH_ORG
+          graph_config_file: $GRAPH_CONFIG_FILE

--- a/.github/workflows/graph-staging.yaml
+++ b/.github/workflows/graph-staging.yaml
@@ -2,7 +2,7 @@ name: Deploy Graph
 
 on:
   push:
-    branches: [master]
+    branches: [staging]
 
 jobs:
   deploy:
@@ -10,7 +10,7 @@ jobs:
     env:
       GRAPH_SUBGRAPH_NAME: subgraph-template
       GRAPH_CONFIG_FILE: subgraph.yaml
-      NETWORK_NAME: mainnet
+      NETWORK_NAME: mumbai
     steps:
       - uses: actions/checkout@v2
       - name: Install node

--- a/.github/workflows/graph-staging.yaml
+++ b/.github/workflows/graph-staging.yaml
@@ -1,4 +1,4 @@
-name: Deploy Graph
+name: Deploy Graph to Mumbai
 
 on:
   push:

--- a/.github/workflows/graph-staging.yaml
+++ b/.github/workflows/graph-staging.yaml
@@ -8,6 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
+      GRAPH_SUBGRAPH_ACCOUNT: ${{ github.repository_owner }}
       GRAPH_SUBGRAPH_NAME: subgraph-template
       GRAPH_CONFIG_FILE: subgraph.yaml
       NETWORK_NAME: mumbai
@@ -23,7 +24,7 @@ jobs:
         run: yarn codegen
       - uses: gtaschuk/graph-deploy@v0.1.0
         with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_access_token: ${{ secrets.GRAPH_ACCESS_TOKEN }}
           graph_subgraph_name: $GRAPH_SUBGRAPH_NAME
-          graph_account: ${{github.repository_owner}}
+          graph_account: $GRAPH_SUBGRAPH_ACCOUNT
           graph_config_file: $GRAPH_CONFIG_FILE

--- a/.github/workflows/graph.yaml
+++ b/.github/workflows/graph.yaml
@@ -8,9 +8,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
+      GRAPH_SUBGRAPH_ACCOUNT: ${{ github.repository_owner }}
       GRAPH_SUBGRAPH_NAME: subgraph-template
       GRAPH_CONFIG_FILE: subgraph.yaml
-      NETWORK_NAME: mainnet
+      NETWORK_NAME: mumbai
     steps:
       - uses: actions/checkout@v2
       - name: Install node
@@ -23,7 +24,7 @@ jobs:
         run: yarn codegen
       - uses: gtaschuk/graph-deploy@v0.1.0
         with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_access_token: ${{ secrets.GRAPH_ACCESS_TOKEN }}
           graph_subgraph_name: $GRAPH_SUBGRAPH_NAME
-          graph_account: ${{github.repository_owner}}
+          graph_account: $GRAPH_SUBGRAPH_ACCOUNT
           graph_config_file: $GRAPH_CONFIG_FILE

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/
 # Subgraph stuff
 subgraph.yaml
 src/types/
+
+# Jetbrains
+.idea/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint ./src",
     "local:create": "graph create --node http://localhost:8020/ ORGANISATION/SUBGRAPH",
     "local:remove": "graph remove --node http://localhost:8020/ ORGANISATION/SUBGRAPH",
-    "local:deploy": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001ORGANISATION/SUBGRAPH",
+    "local:deploy": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 ORGANISATION/SUBGRAPH",
     "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/",
     "deploy:mainnet": "yarn deploy ORGANISATION/SUBGRAPH",
     "codegen": "ts-node ./templatify.ts && graph codegen --debug --output-dir src/types/",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "lint": "eslint ./src",
     "local:create": "graph create --node http://localhost:8020/ ORGANISATION/SUBGRAPH",
     "local:remove": "graph remove --node http://localhost:8020/ ORGANISATION/SUBGRAPH",
-    "local:deploy": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 ORGANISATION/SUBGRAPH",
+    "local:deploy": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001ORGANISATION/SUBGRAPH",
     "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/",
     "deploy:mainnet": "yarn deploy ORGANISATION/SUBGRAPH",
     "codegen": "ts-node ./templatify.ts && graph codegen --debug --output-dir src/types/",
     "codegen:mainnet": "NETWORK_NAME=mainnet yarn codegen",
-    "publish-graph:mainnet": "yarn prepare:mainnet && yarn deploy:mainnet"
+    "publish-graph:mainnet": "yarn codegen:mainnet && yarn deploy:mainnet"
   },
   "repository": {
     "type": "git",
@@ -22,6 +22,10 @@
     {
       "name": "Tom French",
       "url": "https://github.com/tomafrench"
+    },
+    {
+      "name": "Dylan Golow",
+      "url": "https://github.com/dylangolow"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
Updates
* Env variable to set network at env level when calling codegen with network in command name
* Manual action added with `graph-manual.yaml` to trigger from GitHub actions UI to set branch, network, subgraph name and account
* Staging added for mumbai as example with graph-staging.yaml
